### PR TITLE
fix baseUrls for cypress

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,3 @@
 {
-    "baseUrl": "http://localhost:3000/"
+    "baseUrl": "http://excursions.test/"
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "test": "start-server-and-test start http://localhost:3000 cy:run"
+    "test": "CYPRESS_baseUrl=http://localhost:3000 start-server-and-test start http://localhost:3000 cy:run"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
When cypress runs on the CI, it should use localhost:3000 as base. (Added in the package.json script)

And when we run it, it will use the cypress.json variable.